### PR TITLE
Add alt management window with search

### DIFF
--- a/QDKP2_GUI/Code/AltManagement.lua
+++ b/QDKP2_GUI/Code/AltManagement.lua
@@ -1,0 +1,68 @@
+-- Copyright 2025 Your Name
+-- This file is a part of QDKP_V2 (see about.txt in the Addon's root folder)
+
+--                   ## GUI ##
+--              Alt Management Window
+--
+
+local AltManagement = {}
+
+function AltManagement:Show(mainCharacter)
+  self.mainCharacter = mainCharacter
+  QDKP2_AltManagementFrame:Show()
+  self:UpdateCharacterList()
+end
+
+function AltManagement:Hide()
+  QDKP2_AltManagementFrame:Hide()
+end
+
+function AltManagement:UpdateCharacterList(filter)
+  local scrollFrame = QDKP2_AltManagementFrame_ScrollFrame
+  local characterList = {}
+
+  -- Populate characterList with all characters in the guild
+  for i = 1, GetNumGuildMembers(true) do
+    local name, _, _, _, _, _, _, _, _, online = QDKP2_GetGuildRosterInfo(i)
+    if name and name ~= self.mainCharacter then
+      if not filter or string.find(string.lower(name), string.lower(filter)) then
+        table.insert(characterList, {name = name, online = online})
+      end
+    end
+  end
+
+  -- Sort the list alphabetically
+  table.sort(characterList, function(a, b) return a.name < b.name end)
+
+  -- Clear existing entries
+  for i = 1, 20 do
+    local entry = _G["QDKP2_AltManagementFrame_Entry"..i]
+    entry:Hide()
+  end
+
+  -- Populate the list
+  for i, char in ipairs(characterList) do
+    if i > 20 then break end
+    local entry = _G["QDKP2_AltManagementFrame_Entry"..i]
+    entry.characterName = char.name
+    _G[entry:GetName().."_Name"]:SetText(char.name)
+    if char.online then
+      _G[entry:GetName().."_Name"]:SetTextColor(1, 1, 1)
+    else
+      _G[entry:GetName().."_Name"]:SetTextColor(0.5, 0.5, 0.5)
+    end
+    entry:Show()
+  end
+end
+
+function AltManagement:OnSearchTextChanged()
+  self:UpdateCharacterList(QDKP2_AltManagementFrame_SearchBox:GetText())
+end
+
+function AltManagement:AssignAlt(altName)
+  if self.mainCharacter and altName then
+    QDKP2_MakeAlt(altName, self.mainCharacter, true)
+  end
+end
+
+QDKP2GUI_AltManagement = AltManagement

--- a/QDKP2_GUI/Code/Roster.lua
+++ b/QDKP2_GUI/Code/Roster.lua
@@ -88,7 +88,7 @@ function myClass.Refresh(self, forceResort)
     QDKP2frame2_selectList_Bid:SetChecked(false)
     --QDKP2frame2_selectList_Session:SetChecked(false)
 
-    myClass:PupulateList(self)  ----addself
+    self:PupulateList()  ----addself
 
     if self.Sel=="guild" or self.Sel=="custom" then
       myClass:ShowColumn('deltatotal', false)
@@ -271,23 +271,45 @@ function myClass.Update(self)
   GuildRoster()
 end
 
-function myClass.PupulateList(self)
+function myClass.OnSearchTextChanged(self)
+  self:PupulateList(QDKP2_Roster_SearchBox:GetText())
+  self:Refresh(true)
+end
+
+function myClass.PupulateList(self, filter)
   if self.Sel=='guild' then
-    self.List=QDKP2name
+    self.List = {}
+    for _, name in ipairs(QDKP2name) do
+      if not filter or string.find(string.lower(name), string.lower(filter)) then
+        table.insert(self.List, name)
+      end
+    end
     QDKP2frame2_selectList_guild:SetChecked(true)
-	elseif self.Sel=='custom' then
-		self.List=QDKP2GUI_Vars.CustomPlayerRosterList
-		QDKP2frame2_selectList_Custom:SetChecked(true)
+  elseif self.Sel=='custom' then
+    self.List = {}
+    for _, name in ipairs(QDKP2GUI_Vars.CustomPlayerRosterList) do
+      if not filter or string.find(string.lower(name), string.lower(filter)) then
+        table.insert(self.List, name)
+      end
+    end
+    QDKP2frame2_selectList_Custom:SetChecked(true)
   elseif self.Sel=='raid' then
     if QDKP2GUI_Vars.ShowOutGuild then
       local list={}
       for i=1,QDKP2_GetNumRaidMembers() do
         local name = QDKP2_GetRaidRosterInfo(i)
-        table.insert(list,name)
+        if not filter or string.find(string.lower(name), string.lower(filter)) then
+          table.insert(list,name)
+        end
       end
       self.List=list
     else
-      self.List=QDKP2raid
+      self.List = {}
+      for _, name in ipairs(QDKP2raid) do
+        if not filter or string.find(string.lower(name), string.lower(filter)) then
+          table.insert(self.List, name)
+        end
+      end
     end
   elseif self.Sel=='bid' then
     self.List=QDKP2_CopyTable(QDKP2_BidM_GetBidderList())
@@ -420,7 +442,7 @@ end
 function myClass.ChangeList(self,Type)
   QDKP2_Debug(2, "GUI-Roster","Changing view to "..tostring(Type))
   self.Sel=Type
-  myClass:PupulateList()
+  self:PupulateList()
   local list={}
   for i,v in pairs(self.List) do
     if myClass:isSelectedPlayer(v) then table.insert(list,v); end
@@ -848,6 +870,12 @@ function myClass.PlayerMenu(self,List)
   local managing=QDKP2_ManagementMode()
   local sel=List or self.SelectedPlayers
   local menu={}
+
+  if #sel == 1 then
+    table.insert(menu, {text = "Make Alt", func = function()
+      QDKP2GUI_AltManagement:Show(sel[1])
+    end})
+  end
 
   table.insert(menu,LogVoices.QuickMod)
   table.insert(menu,LogVoices.Revert)

--- a/QDKP2_GUI/QDKP2_GUI.toc
+++ b/QDKP2_GUI/QDKP2_GUI.toc
@@ -15,6 +15,7 @@ Code\main.lua
 Code\minimap_button.lua
 Code\Misc.lua
 Code\Roster.lua
+Code\AltManagement.lua
 Code\ToolBox.lua
 Code\Init.lua
 code\LogEntryMod.lua

--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -1353,7 +1353,7 @@
   </Layers>
 
   <Frames>
-       <Button name="$parent_Button1" inherits="UIPanelCloseButton">
+    <Button name="$parent_Button1" inherits="UIPanelCloseButton">
       <Anchors>
         <Anchor point="TOPRIGHT">
           <Offset>
@@ -1367,6 +1367,23 @@
         </OnClick>
       </Scripts>
     </Button>
+    <EditBox name="QDKP2_Roster_SearchBox" inherits="InputBoxTemplate">
+      <Size>
+        <AbsDimension x="150" y="25"/>
+      </Size>
+      <Anchors>
+        <Anchor point="TOPRIGHT">
+          <Offset>
+            <AbsDimension x="-30" y="-13"/>
+          </Offset>
+        </Anchor>
+      </Anchors>
+      <Scripts>
+        <OnTextChanged>
+          QDKP2GUI_Roster:OnSearchTextChanged()
+        </OnTextChanged>
+      </Scripts>
+    </EditBox>
 
     <!-- UICheckButtonTemplate -->
     <CheckButton name="QDKP2frame2_selectList_guild" inherits="UICheckButtonTemplate" id="16" text="">
@@ -2858,6 +2875,279 @@
       </OnLoad>
     </Scripts>
   </Frame>
+  <Frame name="QDKP2_AltManagementFrame" inherits="QDKP2DialogTitled" hidden="true">
+    <Size>
+      <AbsDimension x="350" y="400" />
+    </Size>
+    <Anchors>
+      <Anchor point="CENTER" />
+    </Anchors>
+    <Layers>
+      <Layer level="ARTWORK">
+        <FontString name="$parent_Header" inherits="GameFontNormalLarge" text="Assign Alts">
+          <Anchors>
+            <Anchor point="TOP" relativePoint="TOP">
+              <Offset>
+                <AbsDimension x="0" y="-12" />
+              </Offset>
+            </Anchor>
+          </Anchors>
+        </FontString>
+      </Layer>
+    </Layers>
+    <Frames>
+      <Button name="$parent_CloseButton" inherits="UIPanelCloseButton">
+        <Anchors>
+          <Anchor point="TOPRIGHT">
+            <Offset>
+              <AbsDimension x="-4" y="-4" />
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:Hide()
+          </OnClick>
+        </Scripts>
+      </Button>
+      <EditBox name="$parent_SearchBox" inherits="InputBoxTemplate">
+        <Size>
+          <AbsDimension x="200" y="25" />
+        </Size>
+        <Anchors>
+          <Anchor point="TOP" relativePoint="TOP">
+            <Offset>
+              <AbsDimension x="0" y="-40" />
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Scripts>
+          <OnTextChanged>
+            QDKP2GUI_AltManagement:OnSearchTextChanged()
+          </OnTextChanged>
+        </Scripts>
+      </EditBox>
+      <ScrollFrame name="$parent_ScrollFrame" inherits="FauxScrollFrameTemplate">
+        <Anchors>
+          <Anchor point="TOPLEFT">
+            <Offset>
+              <AbsDimension x="20" y="-70" />
+            </Offset>
+          </Anchor>
+          <Anchor point="BOTTOMRIGHT">
+            <Offset>
+              <AbsDimension x="-35" y="20" />
+            </Offset>
+          </Anchor>
+        </Anchors>
+      </ScrollFrame>
+      <Button name="$parent_Entry1" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_ScrollFrame">
+            <Offset>
+              <AbsDimension x="0" y="0" />
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry2" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry1" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry3" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry2" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry4" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry3" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry5" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry4" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry6" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry5" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry7" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry6" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry8" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry7" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry9" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry8" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry10" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry9" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry11" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry10" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry12" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry11" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry13" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry12" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry14" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry13" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry15" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry14" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry16" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry15" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry17" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry16" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry18" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry17" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry19" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry18" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+      <Button name="$parent_Entry20" inherits="QDKP2_frame2_entry_template">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parent_Entry19" relativePoint="BOTTOMLEFT" />
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            QDKP2GUI_AltManagement:AssignAlt(self.characterName)
+          </OnClick>
+        </Scripts>
+      </Button>
+    </Frames>
+  </Frame>
 </Ui>
+
 
 


### PR DESCRIPTION
## Summary
- implement AltManagement.lua for dedicated alt window
- add search box to roster and populate list filtering
- include alt management frame in GUI XML
- extend player menu with Make Alt option
- load new script in GUI toc

## Testing
- `luac -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6876853e94b08324840e735a9d4f97eb