### PR TITLE
Fix script load order in GUI XML

### DIFF
--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -4,7 +4,13 @@
            ## GRAPHICAL USER INTERFACE ##
 
 -->
-<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/">
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+    <Script file="Code\Log.lua"/>
+    <Script file="Code\Log.Player.lua"/>
+    <Script file="Code\Roster.lua"/>
+    <Script file="Code\ToolBox.lua"/>
+    <Script file="Code\AltManagement.lua"/>
 
   <Frame name="QDKP2GUI">
     <Scripts>


### PR DESCRIPTION
## Summary
- add missing UI schema reference in `QDKP2_GUI.xml`
- load GUI Lua files explicitly at the start of the XML file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68769b8536708324924550fcdee6b9e7