### PR TITLE
Fix Alt Management window layout and logic

### DIFF
--- a/QDKP2_GUI/Code/AltManagement.lua
+++ b/QDKP2_GUI/Code/AltManagement.lua
@@ -6,7 +6,7 @@
 --
 
 local AltManagement = {}
-AltManagement.ENTRIES_PER_PAGE = 18
+AltManagement.ENTRIES_PER_PAGE = 20 -- Increased to match XML
 AltManagement.listData = {} -- This will hold the structured list of mains and alts
 
 function AltManagement:Show(mainCharacter)
@@ -20,7 +20,13 @@ function AltManagement:Show(mainCharacter)
 end
 
 function AltManagement:Hide()
-    self.Frame:Hide()
+    if self.Frame then
+        self.Frame:Hide()
+    end
+end
+
+function AltManagement:OnSearchTextChanged()
+    self:BuildAndDisplayList()
 end
 
 function AltManagement:BuildAndDisplayList()
@@ -46,7 +52,7 @@ function AltManagement:BuildAndDisplayList()
     
     -- Now build the flat display list from the structured data
     local sortedMains = {}
-    for name, _ in pairs(mains) do
+    for name, data in pairs(mains) do
         table.insert(sortedMains, name)
     end
     table.sort(sortedMains)
@@ -69,12 +75,12 @@ function AltManagement:BuildAndDisplayList()
         
         if not filter or mainMatches or altMatches then
             -- Add the main character to the list
-            table.insert(self.listData, { name = name, indent = 0, isMain = true, isCurrentMain = isMainCharacter })
+            table.insert(self.listData, { name = name, indent = 5, isMain = true, isCurrentMain = isMainCharacter })
             
             -- Add their existing alts
             table.sort(data.alts)
             for _, altName in ipairs(data.alts) do
-                table.insert(self.listData, { name = altName, indent = 15, isAlt = true, main = name })
+                table.insert(self.listData, { name = altName, indent = 25, isAlt = true, main = name })
             end
         end
     end
@@ -88,6 +94,12 @@ function AltManagement:PopulateVisibleList()
     
     for i = 1, self.ENTRIES_PER_PAGE do
         local entryFrame = _G["QDKP2_AltManagementFrame_ListContainer_Entry"..i]
+        
+        if not entryFrame then 
+            -- This check prevents errors if the XML hasn't loaded yet.
+            return 
+        end
+
         local dataIndex = i + offset
         local data = self.listData[dataIndex]
         
@@ -105,7 +117,7 @@ function AltManagement:PopulateVisibleList()
             -- Set colors and status text
             if data.isCurrentMain then
                 nameLabel:SetTextColor(1, 0.82, 0)
-                statusLabel:SetText("|cffffd100(Main)|r")
+                statusLabel:SetText("|cffffd100(Current Main)|r")
                 actionButton:Hide()
             elseif data.isMain then
                 nameLabel:SetTextColor(1, 1, 1)

--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -2882,11 +2882,19 @@
     </Scripts>
   </Frame>
   <Frame name="QDKP2_AltManagement_EntryTemplate" virtual="true">
-    <Size x="280" y="18"/>
+    <Size x="350" y="18"/>
     <Layers>
       <Layer level="ARTWORK">
-        <FontString name="$parent_Name" inherits="GameFontNormalSmall" justifyH="LEFT"/>
-        <FontString name="$parent_Status" inherits="GameFontNormalSmall" justifyH="RIGHT"/>
+        <FontString name="$parent_Name" inherits="GameFontNormalSmall" justifyH="LEFT">
+          <Anchors>
+            <Anchor point="LEFT" x="5" y="0"/>
+          </Anchors>
+        </FontString>
+        <FontString name="$parent_Status" inherits="GameFontNormalSmall" justifyH="RIGHT">
+           <Anchors>
+            <Anchor point="RIGHT" x="-80" y="0"/>
+          </Anchors>
+        </FontString>
       </Layer>
     </Layers>
     <Frames>
@@ -2906,7 +2914,7 @@
   </Frame>
 
   <Frame name="QDKP2_AltManagementFrame" inherits="QDKP2DialogTitled" hidden="true">
-    <Size x="400" y="500" />
+    <Size x="450" y="500" />
     <Anchors>
       <Anchor point="CENTER" />
     </Anchors>
@@ -2950,53 +2958,51 @@
         </Anchors>
         <Scripts>
           <OnTextChanged>
-        QDKP2GUI_AltManagement:BuildAndDisplayList()
-      </OnTextChanged>
-  <OnEnterPressed>
-        self:ClearFocus();
-      </OnEnterPressed>
-    </Scripts>
+            QDKP2GUI_AltManagement:BuildAndDisplayList()
+          </OnTextChanged>
+          <OnEnterPressed>
+            self:ClearFocus();
+          </OnEnterPressed>
+        </Scripts>
       </EditBox>
       <Frame name="$parent_ListContainer">
-        <Size x="350" y="360"/>
+        <Size x="400" y="360"/>
         <Anchors>
-          <Anchor point="TOP" relativeTo="$parent_SearchBox" relativePoint="BOTTOM">
-            <Offset x="0" y="-10"/>
-          </Anchor>
+            <Anchor point="TOP" relativeTo="$parent_SearchBox" relativePoint="BOTTOM">
+                <Offset x="0" y="-10"/>
+            </Anchor>
         </Anchors>
-        <Frames>
-            </Frames>
       </Frame>
       <ScrollFrame name="$parent_ScrollFrame" inherits="FauxScrollFrameTemplate">
         <Anchors>
           <Anchor point="TOPRIGHT" relativeTo="$parent_ListContainer" relativePoint="TOPRIGHT">
-    <Offset x="25" y="-2"/>
-  </Anchor>
+            <Offset x="25" y="-2"/>
+          </Anchor>
           <Anchor point="BOTTOMRIGHT" relativeTo="$parent_ListContainer" relativePoint="BOTTOMRIGHT">
-    <Offset x="25" y="2"/>
-  </Anchor>
+            <Offset x="25" y="2"/>
+          </Anchor>
         </Anchors>
-<Scripts>
-  <OnVerticalScroll>
-    FauxScrollFrame_OnVerticalScroll(self, offset, 18, QDKP2GUI_AltManagement.PopulateVisibleList);
-  </OnVerticalScroll>
-</Scripts>
+        <Scripts>
+          <OnVerticalScroll>
+            FauxScrollFrame_OnVerticalScroll(self, offset, 18, QDKP2GUI_AltManagement.PopulateVisibleList);
+          </OnVerticalScroll>
+        </Scripts>
       </ScrollFrame>
     </Frames>
-<Scripts>
-<OnLoad>
-QDKP2GUI_AltManagement.Frame = self;
-for i=1, 18 do
-local entry = CreateFrame("Frame", "$parent_ListContainer_Entry" .. i, self:GetParent().ListContainer, "QDKP2_AltManagement_EntryTemplate")
-if i == 1 then
-entry:SetPoint("TOPLEFT", 10, 0);
-else
-entry:SetPoint("TOPLEFT", _G["QDKP2_AltManagementFrame_ListContainer_Entry" .. (i-1)], "BOTTOMLEFT", 0, -2);
-end
-end
-</OnLoad>
-</Scripts>
-  </Frame>
+    <Scripts>
+      <OnLoad>
+        QDKP2GUI_AltManagement.Frame = self;
+        for i=1, 20 do -- Increased to 20 entries
+          local entry = CreateFrame("Frame", self:GetName() .. "_ListContainer_Entry" .. i, self.ListContainer, "QDKP2_AltManagement_EntryTemplate")
+          if i == 1 then
+            entry:SetPoint("TOPLEFT", 10, 0);
+          else
+            entry:SetPoint("TOPLEFT", _G[self:GetName() .. "_ListContainer_Entry" .. (i-1)], "BOTTOMLEFT", 0, -2);
+          end
+        end
+      </OnLoad>
+    </Scripts>
+      </Frame>
 </Ui>
 
 


### PR DESCRIPTION
## Summary
- widen and correct Alt Management frame XML layout
- create 20 entry frames on load
- refresh Lua logic for new layout and nil checks

## Testing
- `luac -p QDKP2_GUI/Code/AltManagement.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6876e2e4c2148324afc6b713b1ff8911