### PR TITLE
Revamp Alt Management window

### DIFF
--- a/QDKP2_GUI/Code/AltManagement.lua
+++ b/QDKP2_GUI/Code/AltManagement.lua
@@ -1,195 +1,158 @@
 local AltManagement = {}
-AltManagement.ENTRIES_PER_PAGE = 22
-AltManagement.listData = {}
-AltManagement.isInitialized = false -- We'll use this to build the UI only once
+AltManagement.isInitialized = false
 
--- This function creates all the necessary frames programmatically
-function AltManagement:CreateFrames()
+-- This function runs once to create all the UI elements we need
+function AltManagement:Initialize()
     if self.isInitialized then return end
 
-    local parentFrame = QDKP2_AltManagementFrame
-    
-    -- Create the ScrollFrame
-    local scrollFrame = CreateFrame("ScrollFrame", "$parent_ScrollFrame", parentFrame, "FauxScrollFrameTemplate")
-    scrollFrame:SetSize(420, 400)
-    scrollFrame:SetPoint("TOP", QDKP2_AltManagementFrame_SearchBox, "BOTTOM", 0, -10)
-    scrollFrame:SetScript("OnVerticalScroll", function(self, offset)
-        FauxScrollFrame_OnVerticalScroll(self, offset, 18, QDKP2GUI_AltManagement.PopulateVisibleList)
-    end)
-    self.ScrollFrame = scrollFrame
+    -- Left Panel (Current Alts)
+    self.currentAltEntries = {}
+    local leftParent = QDKP2_AltManagementFrame_LeftPanel
+    for i = 1, 22 do
+        local entry = CreateFrame("Frame", nil, leftParent, "QDKP2_AltManagement_CurrentAltTemplate")
+        if i == 1 then
+            entry:SetPoint("TOPLEFT", 10, -30)
+        else
+            entry:SetPoint("TOPLEFT", self.currentAltEntries[i-1], "BOTTOMLEFT", 0, -2)
+        end
+        self.currentAltEntries[i] = entry
+    end
 
-    -- Create the scrollable container
+    -- Right Panel (Available Characters)
+    self.availableCharEntries = {}
+    local scrollFrame = QDKP2_AltManagementFrame_RightPanel_ScrollFrame
     local scrollChild = CreateFrame("Frame", nil, scrollFrame)
-    scrollChild:SetSize(420, 400)
+    scrollChild:SetSize(220, 380)
     scrollFrame:SetScrollChild(scrollChild)
-
-    -- Create and parent the list entries
-    self.entries = {}
+    
     local previousEntry
-    for i=1, self.ENTRIES_PER_PAGE do
-        local entry = CreateFrame("Frame", nil, scrollChild)
-        entry:SetSize(400, 18)
-        entry:SetID(i)
-
-        local name = entry:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
-        name:SetPoint("LEFT", 5, 0)
-        entry.Name = name
-
-        local status = entry:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
-        status:SetPoint("RIGHT", -80, 0)
-        entry.Status = status
-
-        local button = CreateFrame("Button", nil, entry, "UIPanelButtonTemplate")
-        button:SetSize(70, 16)
-        button:SetPoint("RIGHT", -5, 0)
-        button:SetScript("OnClick", function() self:HandleActionClick(entry) end)
-        entry.ActionButton = button
-        
-        local hl = entry:CreateTexture(nil, "HIGHLIGHT")
-        hl:SetAllPoints(true)
-        hl:SetTexture("Interface\\QuestFrame\\UI-QuestTitleHighlight")
-        hl:SetBlendMode("ADD")
-        
+    for i = 1, 20 do
+        local entry = CreateFrame("Frame", nil, scrollChild, "QDKP2_AltManagement_AvailableAltTemplate")
         if i == 1 then
             entry:SetPoint("TOPLEFT", 5, -5)
         else
             entry:SetPoint("TOPLEFT", previousEntry, "BOTTOMLEFT", 0, -2)
         end
         previousEntry = entry
-        self.entries[i] = entry
+        self.availableCharEntries[i] = entry
     end
     
     self.isInitialized = true
 end
 
 function AltManagement:Show(mainCharacter)
-    self:CreateFrames() -- Create frames if they don't exist
+    self:Initialize() -- Create frames if they don't exist yet
     
     self.mainCharacter = mainCharacter
     if not self.mainCharacter then return end
 
     QDKP2_AltManagementFrame:Show()
-    QDKP2_AltManagementFrame_SubHeader:SetText("Managing alts for: |cffffd100" .. self.mainCharacter .. "|r")
-    QDKP2_AltManagementFrame_SearchBox:SetText("")
-    QDKP2_AltManagementFrame_SearchBox:ClearFocus()
-    self:BuildAndDisplayList()
+    QDKP2_AltManagementFrame_RightPanel_SearchBox:SetText("")
+    QDKP2_AltManagementFrame_RightPanel_SearchBox:ClearFocus()
+    
+    self:UpdateAllLists()
 end
 
 function AltManagement:Hide()
     QDKP2_AltManagementFrame:Hide()
 end
 
-function AltManagement:BuildAndDisplayList()
-    local filter = QDKP2_AltManagementFrame_SearchBox:GetText()
-    filter = (filter and filter ~= "") and string.lower(filter) or nil
-    
-    wipe(self.listData)
+function AltManagement:UpdateAllLists()
+    self:UpdateCurrentAltsList()
+    self:UpdateAvailableCharsList()
+end
 
-    local mains = {}
+-- Logic for the LEFT panel
+function AltManagement:UpdateCurrentAltsList()
+    -- Add the main character at the top
+    local displayList = { {name = self.mainCharacter, isMain = true} }
+    
+    -- Find all alts for the current main
     for i = 1, QDKP2_GetNumGuildMembers(true) do
         local name = QDKP2_GetGuildRosterInfo(i)
-        if name then
-            local mainName = QDKP2_GetMain(name)
-            if not mains[mainName] then
-                mains[mainName] = { alts = {} }
-            end
-            if mainName ~= name then
-                table.insert(mains[mainName].alts, name)
-            end
+        if name and QDKP2_GetMain(name) == self.mainCharacter and name ~= self.mainCharacter then
+            table.insert(displayList, {name = name, isAlt = true})
         end
     end
     
-    local sortedMains = {}
-    for name in pairs(mains) do
-        table.insert(sortedMains, name)
-    end
-    table.sort(sortedMains)
-
-    for _, name in ipairs(sortedMains) do
-        local data = mains[name]
-        local isMainCharacter = (name == self.mainCharacter)
-        
-        local mainMatches = filter and string.find(string.lower(name), filter)
-        local altMatches = false
-        if filter then
-            for _, altName in ipairs(data.alts) do
-                if string.find(string.lower(altName), filter) then
-                    altMatches = true
-                    break
-                end
-            end
-        end
-        
-        if not filter or mainMatches or altMatches then
-            table.insert(self.listData, { name = name, indent = 5, isMain = true, isCurrentMain = isMainCharacter })
-            table.sort(data.alts)
-            for _, altName in ipairs(data.alts) do
-                table.insert(self.listData, { name = altName, indent = 25, isAlt = true, main = name })
-            end
-        end
-    end
-    
-    self:PopulateVisibleList()
-end
-
-function AltManagement:PopulateVisibleList()
-    if not self.isInitialized then return end
-
-    local offset = FauxScrollFrame_GetOffset(self.ScrollFrame)
-    
-    for i = 1, self.ENTRIES_PER_PAGE do
-        local entryFrame = self.entries[i]
-        local data = self.listData[i + offset]
-        
+    -- Populate the UI
+    for i, entry in ipairs(self.currentAltEntries) do
+        local data = displayList[i]
         if data then
-            entryFrame.characterStatus = data
-            entryFrame.Name:SetPoint("LEFT", data.indent, 0)
-            entryFrame.Name:SetText(data.name)
+            local nameLabel = _G[entry:GetName().."_Name"]
+            local actionButton = _G[entry:GetName().."_ActionButton"]
+
+            nameLabel:SetText(data.name)
+            nameLabel:SetPoint("LEFT", data.isAlt and 20 or 5, 0)
             
-            if data.isCurrentMain then
-                entryFrame.Name:SetTextColor(1, 0.82, 0)
-                entryFrame.Status:SetText("|cffffd100(Current Main)|r")
-                entryFrame.ActionButton:Hide()
-            elseif data.isMain then
-                entryFrame.Name:SetTextColor(1, 1, 1)
-                entryFrame.Status:SetText("")
-                entryFrame.ActionButton:SetText("Assign")
-                entryFrame.ActionButton:Show()
-            elseif data.isAlt then
-                entryFrame.Name:SetTextColor(0.8, 0.8, 0.8)
-                if data.main then
-                    entryFrame.Status:SetText("|cffaaaaaa(Alt of " .. data.main .. ")|r")
-                else
-                    entryFrame.Status:SetText("|cffff0000(Error: No Main)|r")
-                end
-                
-                if data.main == self.mainCharacter then
-                    entryFrame.ActionButton:SetText("Remove")
-                    entryFrame.ActionButton:Show()
-                else
-                    entryFrame.ActionButton:Hide()
-                end
+            if data.isMain then
+                nameLabel:SetTextColor(1, 0.82, 0)
+                actionButton:Hide()
+            else -- isAlt
+                nameLabel:SetTextColor(0.8, 0.8, 0.8)
+                actionButton:SetText("Remove")
+                entry.characterName = data.name
+                actionButton:Show()
             end
-            entryFrame:Show()
+            entry:Show()
         else
-            entryFrame:Hide()
+            entry:Hide()
+        end
+    end
+end
+
+-- Logic for the RIGHT panel
+function AltManagement:UpdateAvailableCharsList()
+    local filter = QDKP2_AltManagementFrame_RightPanel_SearchBox:GetText()
+    filter = (filter and filter ~= "") and string.lower(filter) or nil
+    
+    self.availableChars = {}
+    for i = 1, QDKP2_GetNumGuildMembers(true) do
+        local name = QDKP2_GetGuildRosterInfo(i)
+        if name and not QDKP2_IsAlt(name) and name ~= self.mainCharacter then
+            if not filter or string.find(string.lower(name), filter) then
+                table.insert(self.availableChars, name)
+            end
+        end
+    end
+    table.sort(self.availableChars)
+    self:PopulateAvailableCharsList()
+end
+
+function AltManagement:PopulateAvailableCharsList()
+    local scrollFrame = QDKP2_AltManagementFrame_RightPanel_ScrollFrame
+    local offset = FauxScrollFrame_GetOffset(scrollFrame)
+
+    for i, entry in ipairs(self.availableCharEntries) do
+        local name = self.availableChars[i + offset]
+        if name then
+            local nameLabel = _G[entry:GetName().."_Name"]
+            local actionButton = _G[entry:GetName().."_ActionButton"]
+            
+            nameLabel:SetText(name)
+            actionButton:SetText("Assign")
+            entry.characterName = name
+            entry:Show()
+        else
+            entry:Hide()
         end
     end
     
-    FauxScrollFrame_Update(self.ScrollFrame, #self.listData, self.ENTRIES_PER_PAGE, 18)
+    FauxScrollFrame_Update(scrollFrame, #self.availableChars, self.ENTRIES_PER_PAGE, 18)
 end
 
-function AltManagement:HandleActionClick(entryFrame)
-    local status = entryFrame.characterStatus
-    if not status then return end
-
-    if status.isMain then
-        QDKP2_MakeAlt(status.name, self.mainCharacter, true)
-    elseif status.isAlt and status.main == self.mainCharacter then
-        QDKP2_ClearAlt(status.name)
+function AltManagement:HandleAssignClick(altName)
+    if self.mainCharacter and altName then
+        QDKP2_MakeAlt(altName, self.mainCharacter, true)
+        self:UpdateAllLists()
     end
-    
-    self:BuildAndDisplayList()
+end
+
+function AltManagement:HandleRemoveClick(altName)
+    if altName then
+        QDKP2_ClearAlt(altName)
+        self:UpdateAllLists()
+    end
 end
 
 -- Initialize the class object

--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -2885,32 +2885,93 @@
 
 
   
-    <Frame name="QDKP2_AltManagementFrame" inherits="QDKP2DialogTitled" hidden="true">
-      <Size x="450" y="500" />
-      <Anchors><Anchor point="CENTER" /></Anchors>
-      <Layers>
-        <Layer level="ARTWORK">
-          <FontString name="$parent_Header" inherits="GameFontNormalLarge" text="ALT MANAGEMENT">
-            <Anchors><Anchor point="TOP" y="-12" /></Anchors>
-          </FontString>
-          <FontString name="$parent_SubHeader" inherits="GameFontNormal">
-            <Anchors><Anchor point="TOP" relativeTo="$parent_Header" relativePoint="BOTTOM" y="-4" /></Anchors>
-          </FontString>
-        </Layer>
-      </Layers>
-      <Frames>
-        <Button name="$parent_CloseButton" inherits="UIPanelCloseButton">
-          <Anchors><Anchor point="TOPRIGHT" x="-4" y="-4" /></Anchors>
-          <Scripts><OnClick>QDKP2GUI_AltManagement:Hide()</OnClick></Scripts>
+  <Frame name="QDKP2_AltManagement_CurrentAltTemplate" virtual="true">
+    <Size x="180" y="18"/>
+    <Layers>
+      <Layer level="ARTWORK">
+        <FontString name="$parent_Name" inherits="GameFontNormalSmall" justifyH="LEFT"/>
+      </Layer>
+    </Layers>
+    <Frames>
+        <Button name="$parent_ActionButton" inherits="UIPanelButtonTemplate">
+            <Size x="60" y="16"/>
+            <Anchors><Anchor point="RIGHT" x="-5" y="0"/></Anchors>
+            <Scripts>
+                <OnClick>QDKP2GUI_AltManagement:HandleRemoveClick(self:GetParent().characterName);</OnClick>
+            </Scripts>
         </Button>
-        <EditBox name="$parent_SearchBox" inherits="InputBoxTemplate" autoFocus="false">
-          <Size x="200" y="25" />
-          <Anchors><Anchor point="TOP" y="-60" /></Anchors>
-          <Scripts>
-            <OnTextChanged>QDKP2GUI_AltManagement:BuildAndDisplayList()</OnTextChanged>
-  <OnEnterPressed>self:ClearFocus();</OnEnterPressed>
-          </Scripts>
-        </EditBox>
-      </Frames>
-    </Frame>
+    </Frames>
+  </Frame>
+  <Frame name="QDKP2_AltManagement_AvailableAltTemplate" virtual="true">
+    <Size x="180" y="18"/>
+    <Layers>
+      <Layer level="ARTWORK">
+        <FontString name="$parent_Name" inherits="GameFontNormalSmall" justifyH="LEFT"/>
+      </Layer>
+    </Layers>
+    <Frames>
+        <Button name="$parent_ActionButton" inherits="UIPanelButtonTemplate">
+            <Size x="60" y="16"/>
+            <Anchors><Anchor point="RIGHT" x="-5" y="0"/></Anchors>
+            <Scripts>
+                <OnClick>QDKP2GUI_AltManagement:HandleAssignClick(self:GetParent().characterName);</OnClick>
+            </Scripts>
+        </Button>
+    </Frames>
+    <HighlightTexture file="Interface\QuestFrame\UI-QuestTitleHighlight" alphaMode="ADD"/>
+  </Frame>
+
+  <Frame name="QDKP2_AltManagementFrame" inherits="QDKP2DialogTitled" hidden="true">
+    <Size x="500" y="500" />
+    <Anchors><Anchor point="CENTER" /></Anchors>
+    <Frames>
+      <Button name="$parent_CloseButton" inherits="UIPanelCloseButton">
+        <Anchors><Anchor point="TOPRIGHT" x="-4" y="-4" /></Anchors>
+        <Scripts><OnClick>QDKP2GUI_AltManagement:Hide()</OnClick></Scripts>
+      </Button>
+      
+      <Frame name="$parent_LeftPanel">
+        <Size x="220" y="440"/>
+        <Anchors><Anchor point="TOPLEFT" x="15" y="-40"/></Anchors>
+        <Layers>
+          <Layer level="ARTWORK">
+            <FontString name="$parent_Title" inherits="GameFontNormalLarge" text="Current Main &amp; Alts">
+              <Anchors><Anchor point="TOP" y="-5"/></Anchors>
+            </FontString>
+          </Layer>
+        </Layers>
+      </Frame>
+
+      <Frame name="$parent_RightPanel">
+        <Size x="220" y="440"/>
+        <Anchors><Anchor point="TOPRIGHT" x="-15" y="-40"/></Anchors>
+        <Frames>
+          <EditBox name="$parent_SearchBox" inherits="InputBoxTemplate" autoFocus="false">
+            <Size x="180" y="25" />
+            <Anchors><Anchor point="TOP" y="-25" /></Anchors>
+            <Scripts>
+              <OnTextChanged>QDKP2GUI_AltManagement:UpdateAvailableCharsList()</OnTextChanged>
+              <OnEnterPressed>self:ClearFocus();</OnEnterPressed>
+            </Scripts>
+          </EditBox>
+          <ScrollFrame name="$parent_ScrollFrame" inherits="FauxScrollFrameTemplate">
+            <Size x="220" y="380"/>
+            <Anchors><Anchor point="TOP" relativeTo="$parent_SearchBox" relativePoint="BOTTOM" x="0" y="-5"/></Anchors>
+            <Scripts>
+                <OnVerticalScroll>
+                    FauxScrollFrame_OnVerticalScroll(self, offset, 18, QDKP2GUI_AltManagement.PopulateAvailableCharsList);
+                </OnVerticalScroll>
+            </Scripts>
+          </ScrollFrame>
+        </Frames>
+        <Layers>
+           <Layer level="ARTWORK">
+            <FontString name="$parent_Title" inherits="GameFontNormalLarge" text="Available Characters">
+              <Anchors><Anchor point="TOP" y="-5"/></Anchors>
+            </FontString>
+          </Layer>
+        </Layers>
+      </Frame>
+    </Frames>
+  </Frame>
 </Ui>


### PR DESCRIPTION
## Summary
- update AltManagementFrame in XML to use a two‑panel layout
- add templates for current and available alt rows
- rewrite AltManagement.lua to create UI elements programmatically and handle assigning/removing alts

## Testing
- `luac -p QDKP2_GUI/Code/AltManagement.lua`

------
https://chatgpt.com/codex/tasks/task_b_6876ee57d1948324b212b763dbcea6be