### PR TITLE
Fix alt management UI errors

### DIFF
--- a/QDKP2_GUI/Code/AltManagement.lua
+++ b/QDKP2_GUI/Code/AltManagement.lua
@@ -18,7 +18,8 @@ function AltManagement:Initialize()
     local leftParent = _G[parentFrame:GetName().."_LeftPanel"]
     local previousLeftEntry
     for i = 1, self.ENTRIES_PER_PAGE do
-        local entry = CreateFrame("Frame", nil, leftParent, "QDKP2_AltManagement_CurrentAltTemplate")
+        local entryName = leftParent:GetName() .. "_Entry" .. i
+        local entry = CreateFrame("Frame", entryName, leftParent, "QDKP2_AltManagement_CurrentAltTemplate")
         if i == 1 then
             entry:SetPoint("TOPLEFT", 10, -30)
         else
@@ -31,14 +32,15 @@ function AltManagement:Initialize()
     -- Create the Right Panel (Available Characters) UI elements
     self.availableCharEntries = {}
     local scrollFrame = _G[parentFrame:GetName().."_RightPanel_ScrollFrame"]
-    local scrollChild = CreateFrame("Frame", nil, scrollFrame)
+    local scrollChild = CreateFrame("Frame", scrollFrame:GetName() .. "_Child", scrollFrame)
     scrollChild:SetSize(220, 380)
     scrollFrame:SetScrollChild(scrollChild)
     self.ScrollFrame = scrollFrame -- Store reference for later
     
     local previousRightEntry
     for i = 1, self.ENTRIES_PER_PAGE do
-        local entry = CreateFrame("Frame", nil, scrollChild, "QDKP2_AltManagement_AvailableAltTemplate")
+        local entryName = scrollChild:GetName() .. "_Entry" .. i
+        local entry = CreateFrame("Frame", entryName, scrollChild, "QDKP2_AltManagement_AvailableAltTemplate")
         if i == 1 then
             entry:SetPoint("TOPLEFT", 5, -5)
         else
@@ -161,7 +163,7 @@ function AltManagement:PopulateAvailableCharsList()
         end
     end
     
-    FauxScrollFrame_Update(self.ScrollFrame, #self.availableChars, #self.entries, 18)
+    FauxScrollFrame_Update(self.ScrollFrame, #self.availableChars, self.ENTRIES_PER_PAGE, 18)
 end
 
 -- Links an alt to a main character and stores the relation

--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -2924,6 +2924,13 @@
   <Frame name="QDKP2_AltManagementFrame" inherits="QDKP2DialogTitled" hidden="true">
     <Size x="500" y="500" />
     <Anchors><Anchor point="CENTER" /></Anchors>
+    <Layers>
+      <Layer level="ARTWORK">
+        <FontString name="$parent_SubHeader" inherits="GameFontNormalSmall">
+          <Anchors><Anchor point="TOP" y="-25"/></Anchors>
+        </FontString>
+      </Layer>
+    </Layers>
     <Frames>
       <Button name="$parent_CloseButton" inherits="UIPanelCloseButton">
         <Anchors><Anchor point="TOPRIGHT" x="-4" y="-4" /></Anchors>


### PR DESCRIPTION
## Summary
- ensure alt management templates have names for frame lookups
- add missing SubHeader element to XML
- correct scroll frame update logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bb81f96f8832496567736f54a743f