### PR TITLE
Fix nil alt management reference

### DIFF
--- a/QDKP2_GUI/Code/Roster.lua
+++ b/QDKP2_GUI/Code/Roster.lua
@@ -872,6 +872,10 @@ function myClass.PlayerMenu(self,List)
   local menu={}
 
   if #sel == 1 then
+    -- Ensure the alt management table exists so calling :Show does not
+    -- throw an error when the roster menu is opened before the frame is
+    -- fully initialised.
+    if QDKP2GUI_AltManagement == nil then QDKP2GUI_AltManagement = {} end
     table.insert(menu, {text = "ALT MANAGEMENT", func = function()
       QDKP2GUI_AltManagement:Show(sel[1])
     end})


### PR DESCRIPTION
## Summary
- prevent lua error when alt management frame hasn't been initialised

## Testing
- `luac -p QDKP2_GUI/Code/Roster.lua`


------
https://chatgpt.com/codex/tasks/task_b_687cf0baac7c83248998ee71c79db865